### PR TITLE
Support local hydra heads

### DIFF
--- a/hydra.el
+++ b/hydra.el
@@ -163,14 +163,18 @@ It's possible to set this to nil.")
       (and (consp x)
            (memq (car x) '(function quote)))))
 
+(defun hydra--head-property (h prop)
+  "Return the value of property PROP for Hydra head H."
+  (let ((plist (if (stringp (cl-caddr h))
+                   (cl-cdddr h)
+                 (cddr h))))
+    (plist-get plist prop)))
+
 (defun hydra--color (h body-color)
   "Return the color of a Hydra head H with BODY-COLOR."
   (if (null (cadr h))
       'blue
-    (let ((plist (if (stringp (cl-caddr h))
-                     (cl-cdddr h)
-                   (cddr h))))
-      (or (plist-get plist :color) body-color))))
+    (or (hydra--head-property h :color) body-color)))
 
 (defun hydra--face (h body-color)
   "Return the face for a Hydra head H with BODY-COLOR."
@@ -393,7 +397,9 @@ in turn can be either red or blue."
        ,@(delq nil
                (cl-mapcar
                 (lambda (head name)
-                  (unless (or (null body-key) (null method))
+                  (unless (or (null body-key)
+                              (null method)
+                              (hydra--head-property head :local))
                     (list
                      (if (hydra--callablep method)
                          'funcall


### PR DESCRIPTION
I'm trying to migrate all my uses of [temporary-mode](https://github.com/ffevotte/temporary-mode) to `hydra`. One of the feature I'm currently missing is the possibility to have "local" heads, i.e. heads that are not bound in the global keymap, but only in the transient keymap. This feature has also been mentioned in the [comments](http://oremacs.com/2015/02/02/colorful-hydrae/#comment-1831113185) of your blog.

This patch should handle such a feature, hopefully without breaking anything. Below is an example use: in this case, you don't want <kbd>C-x j</kbd> and <kbd>C-x k</kbd> to be rebound, just make them available while in the hydra.

```elisp
(defhydra hydra-next-error (custom-bindings-mode-map "C-x")
  "next-error"
  ("`" next-error "next")
  ("j" next-error "next" :local t)
  ("k" previous-error "previous" :local t))
```

Would you find such a feature useful?