### PR TITLE
Fix wrong type argument in hydra-timeout

### DIFF
--- a/hydra.el
+++ b/hydra.el
@@ -772,7 +772,7 @@ Cancel the previous `hydra-timeout'."
   (cancel-timer hydra-timer)
   (setq hydra-timer (timer-create))
   (timer-set-time hydra-timer
-                  (timer-relative-time nil secs))
+                  (timer-relative-time (current-time) secs))
   (timer-set-function
    hydra-timer
    (or function #'hydra-keyboard-quit))


### PR DESCRIPTION
In trying out `:timeout` support, I found that I was getting this:

    timer-relative-time: Wrong type argument: number-or-marker-p, nil

Modifying `hydra-timeout` to set the timer relative to `(current-time)` rather than nil fixes the issue for me.