### PR TITLE
Add lv-delete-window function

### DIFF
--- a/hydra.el
+++ b/hydra.el
@@ -388,10 +388,7 @@ Return DEFAULT if PROP is not in H."
   (cancel-timer hydra-timeout-timer)
   (cancel-timer hydra-message-timer)
   (if hydra-lv
-      (when (window-live-p lv-wnd)
-        (let ((buf (window-buffer lv-wnd)))
-          (delete-window lv-wnd)
-          (kill-buffer buf)))
+      (lv-delete-window)
     (message ""))
   nil)
 

--- a/lv.el
+++ b/lv.el
@@ -73,6 +73,13 @@
     (goto-char (point-min))
     (select-window ori)))
 
+(defun lv-delete-window ()
+  "Delete LV window and kill its buffer."
+  (when (window-live-p lv-wnd)
+    (let ((buf (window-buffer lv-wnd)))
+      (delete-window lv-wnd)
+      (kill-buffer buf))))
+
 (provide 'lv)
 
 ;;; lv.el ends here


### PR DESCRIPTION
I recently tried to simplify `magit-popup.el`, but it's just to obfuscated. So I had a look at `hydra.el` but it's not a perfect match. What is needed for magit's "popups" is more similar to prefix arguments than hydra heads. So am currently writing a new library.

(I like hydra though, I am going to use it - just not in magit. Seems we have some similar ideas about key bindings).

I would like to use `lv.el` though and noticed there is no `lv-delete-window`, so I added it. Without that function every library that uses it would have to contain a copy of those four lines, which frankly are an implementation detail.

----

In `hydra.el` I also noticed a few small issues. I'll report those later. One problem that I ran into while *editing* the code was that you don't set `indent-tabs-mode` to `nil` and instead rely everyone who might edit the code having made that setting globally too. Would you accept a patch to fix that?

In a similar vein, you use custom outline headers but since you continue to use regular headers (and you should) for the header and commentary sections, those are no longer collapsible. This would probably be a more suitable value:

```
;; outline-regexp: ";;\\([;*]+ [^\s\t\n]\\|###autoload\\)\\|("
```