### PR TITLE
Separate lv window and echo area using a thin line

### DIFF
--- a/hydra-examples.el
+++ b/hydra-examples.el
@@ -334,4 +334,9 @@ _h_   _l_   _o_k        _y_ank
       (goto-char mk))))
 
 (provide 'hydra-examples)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; hydra-examples.el ends here

--- a/hydra-init.el
+++ b/hydra-init.el
@@ -25,3 +25,9 @@
 (require 'hydra-examples)
 (require 'hydra-test)
 (mapc #'byte-compile-file '("hydra.el" "hydra-examples.el" "hydra-ox.el" "hydra-test.el" "lv.el"))
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
+;;; hydra-init.el ends here

--- a/hydra-ox.el
+++ b/hydra-ox.el
@@ -115,4 +115,8 @@ _C-a_ Async export: %`hydra-ox/async-export
 
 (provide 'hydra-ox)
 
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; hydra-ox.el ends here

--- a/hydra-test.el
+++ b/hydra-test.el
@@ -1274,4 +1274,8 @@ _w_ Worf:                      % -8`hydra-tng/worf^^    _h_ Set phasers to      
 
 (provide 'hydra-test)
 
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; hydra-test.el ends here

--- a/hydra.el
+++ b/hydra.el
@@ -1026,5 +1026,4 @@ DOC defaults to TOGGLE-NAME split and capitalized."
 ;; outline-regexp: ";;\\([;*]+ [^\s\t\n]\\|###autoload\\)\\|("
 ;; indent-tabs-mode: nil
 ;; End:
-
 ;;; hydra.el ends here

--- a/lv.el
+++ b/lv.el
@@ -33,6 +33,24 @@
 
 ;;; Code:
 
+(defgroup lv nil
+  "The other echo area."
+  :group 'minibuffer
+  :group 'hydra)
+
+(defcustom lv-use-separator nil
+  "Whether to draw a line between the lv window and the echo area."
+  :group 'lv
+  :type 'boolean)
+
+(defface lv-separator
+  '((((class color) (background light)) :background "grey80")
+    (((class color) (background  dark)) :background "grey30"))
+  "Face used to draw line between the lv window and the echo area.
+This is only used if option `lv-use-separator' is non-nil.
+Only the background color is significant."
+  :group 'lv)
+
 (defvar lv-wnd nil
   "Holds the current LV window.")
 
@@ -70,9 +88,16 @@
                    (null lv-force-update))
         (delete-region (point-min) (point-max))
         (insert str)
+        (when (window-system)
+          (unless (string-match-p "\n$" str)
+            (insert "\n"))
+          (insert
+           (propertize "__" 'face 'lv-separator 'display '(space :height (1)))
+           (propertize "\n" 'face 'lv-separator 'line-height t)))
         (setq-local window-min-height n-lines)
         (setq truncate-lines (> n-lines 1))
-        (fit-window-to-buffer nil nil 1))
+        (let ((window-resize-pixelwise t))
+          (fit-window-to-buffer nil nil 1)))
       (goto-char (point-min)))))
 
 (defun lv-delete-window ()

--- a/lv.el
+++ b/lv.el
@@ -84,4 +84,7 @@
 
 (provide 'lv)
 
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
 ;;; lv.el ends here


### PR DESCRIPTION
It's possible to separate the lv window and the echo area using a thin line. What do you think?

If you add this, then we probably also need a boolean option and a face. Also I haven't tested this much yet.