### PR TITLE
lv-window: split-window ignores window parameters

### DIFF
--- a/lv.el
+++ b/lv.el
@@ -62,8 +62,9 @@ Only the background color is significant."
           buf)
       (prog1 (setq lv-wnd
                    (select-window
-                    (split-window
-                     (frame-root-window) -1 'below)))
+                    (let ((ignore-window-parameters t))
+                      (split-window
+                       (frame-root-window) -1 'below))))
         (if (setq buf (get-buffer "*LV*"))
             (switch-to-buffer buf)
           (switch-to-buffer "*LV*")


### PR DESCRIPTION
fix lv-window failure in presence of a bottom window with no-other-window window parameter set to t.

In my use case, lv-window fails any time there's a compilation window open (side-window on the bottom), which is rather often...