### PR TITLE
hydra.el (hydra-width-spec-regex): Fix regex

### DIFF
--- a/hydra.el
+++ b/hydra.el
@@ -590,7 +590,7 @@ HEAD's binding is returned as a string wrapped with [] or {}."
     ("⌦" . "<deletechar>")
     ("⏎" . "RET")))
 
-(defconst hydra-width-spec-regex " ?-?[0-9]*s?"
+(defconst hydra-width-spec-regex " ?-?[0-9]*?"
   "Regex for the width spec in keys and %` quoted sexps.")
 
 (defvar hydra-key-regex "\\[\\|]\\|[-[:alnum:] ~.,;:/|?<>={}*+#%@!&^↑↓←→⌫⌦⏎'`()\"]+?"


### PR DESCRIPTION
This bug breaks key binding in docstring like `[_SPC_]`