### PR TITLE
Move Amaranth warning message to a defvar

### DIFF
--- a/hydra.el
+++ b/hydra.el
@@ -100,6 +100,9 @@
   "If a Hydra head sets this to t, exit the Hydra.
 This will be done even if the head wasn't designated for exiting.")
 
+(defvar hydra-amaranth-warn-message "An amaranth Hydra can only exit through a blue head"
+  "Amaranth Warning message.  Shown when the user tries to press an unbound/non-exit key while in an amaranth head.")
+
 (defun hydra-set-transient-map (keymap on-exit &optional foreign-keys)
   "Set KEYMAP to the highest priority.
 
@@ -185,7 +188,7 @@ warn: keep KEYMAP and issue a warning instead of running the command."
 (defun hydra-amaranth-warn ()
   "Issue a warning that the current input was ignored."
   (interactive)
-  (message "An amaranth Hydra can only exit through a blue head"))
+  (message hydra-amaranth-warn-message))
 
 ;;* Customize
 (defgroup hydra nil


### PR DESCRIPTION
This is the simplest way to achieve #207 

However I think in addition to this, there should be a (built in) way to customise this (and any future) messages, within the defhydra macro.