### PR TITLE
Remove trailing whitespace in docstring generated from heads with :column property

### DIFF
--- a/hydra-test.el
+++ b/hydra-test.el
@@ -1441,7 +1441,7 @@ t: info-to"
 ;; basic rendering
 ;; column compatibility with ruby style and no colum specified
 ;; column declared several time
-;; nil column 
+;; nil column
 (ert-deftest hydra-column-1 ()
   (should (equal (eval
                   (cadr
@@ -1456,7 +1456,7 @@ t: info-to"
 _h_   _l_       (O)(o)
   ^_j_^         (  O )
 ^^^^            (’’)(’’)
-^^^^        
+^^^^
 "
                                  ("h" backward-char nil)
                                  ("l" forward-char nil)
@@ -1476,37 +1476,36 @@ _h_   _l_       (O)(o)
                                  ("o" nil "ok" :column "firstcol")
                                  ("Os" 5x5-bol "outside of table 2" :column nil)
                                  ("Ot" 5x5-eol "outside of table 3")))))))
-
-#("  k         ()()
+                 #("  k         ()()
 h   l       (O)(o)
   j         (  O )
             (’’)(’’)
-        
 
-firstcol    | secondcol    
------------ | ------------ 
-e: exchange | r: reset     
-n: new-copy | y: yank      
-d: delete   | u: undo      
-o: ok       | s: string    
-            | p: paste     
+
+firstcol    | secondcol
+----------- | ------------
+e: exchange | r: reset
+n: new-copy | y: yank
+d: delete   | u: undo
+o: ok       | s: string
+            | p: paste
 [Of]: outside of table 1, [Os]: outside of table 2, [Ot]: outside of table 3."
-2 3 (face hydra-face-pink)
-17 18 (face hydra-face-pink)
-21 22 (face hydra-face-pink)
-38 39 (face hydra-face-pink)
-142 143 (face hydra-face-pink)
-156 157 (face hydra-face-pink)
-170 171 (face hydra-face-pink)
-184 185 (face hydra-face-pink)
-198 199 (face hydra-face-pink)
-212 213 (face hydra-face-pink)
-226 227 (face hydra-face-blue)
-240 241 (face hydra-face-pink)
-268 269 (face hydra-face-pink)
-283 285 (face hydra-face-pink)
-309 311 (face hydra-face-pink)
-335 337 (face hydra-face-pink)))))
+                   2 3 (face hydra-face-pink)
+                   17 18 (face hydra-face-pink)
+                   21 22 (face hydra-face-pink)
+                   38 39 (face hydra-face-pink)
+                   129 130 (face hydra-face-pink)
+                   143 144 (face hydra-face-pink)
+                   152 153 (face hydra-face-pink)
+                   166 167 (face hydra-face-pink)
+                   174 175 (face hydra-face-pink)
+                   188 189 (face hydra-face-pink)
+                   196 197 (face hydra-face-blue)
+                   210 211 (face hydra-face-pink)
+                   234 235 (face hydra-face-pink)
+                   244 246 (face hydra-face-pink)
+                   270 272 (face hydra-face-pink)
+                   296 298 (face hydra-face-pink)))))
 
 
 (provide 'hydra-test)

--- a/hydra.el
+++ b/hydra.el
@@ -1053,25 +1053,26 @@ every heads-group have equal length by adding padding heads where applicable."
        finally return decorated-heads-matrix)))
 
 (defun hydra--hint-from-matrix (body heads-matrix)
-  "Generate a formated table-style docstring according to HEADS-MATRIX and BODY data and structure
+  "Generate a formated table-style docstring according to BODY and HEADS-MATRIX data and structure.
 HEADS-MATRIX is expected to be a list of heads with following features:
 Each heads must have the same length
 Each head must have a property max-key-len and max-doc-len."
   (when heads-matrix
     (cl-loop with first-heads-col = (nth 0 heads-matrix)
-       with last-row-index = (- (length first-heads-col) 1)
-       for row-index from 0 to last-row-index
-       for heads-in-row = (mapcar (lambda (heads) (nth row-index heads)) heads-matrix)
-       concat (concat
-               (mapconcat (lambda (head)
-                            (funcall hydra-key-doc-function
-                                     (hydra-fontify-head head body) ;; key
-                                     (hydra--head-property head :max-key-len)
-                                     (nth 2 head) ;; doc
-                                     (hydra--head-property head :max-doc-len)))
-                          heads-in-row "| ") "\n")
-       into matrix-image
-       finally return matrix-image)))
+             with last-row-index = (- (length first-heads-col) 1)
+             for row-index from 0 to last-row-index
+             for heads-in-row = (mapcar (lambda (heads) (nth row-index heads)) heads-matrix)
+             concat (concat
+                     (replace-regexp-in-string "\s+$" ""
+                                               (mapconcat (lambda (head)
+                                                            (funcall hydra-key-doc-function
+                                                                     (hydra-fontify-head head body) ;; key
+                                                                     (hydra--head-property head :max-key-len)
+                                                                     (nth 2 head) ;; doc
+                                                                     (hydra--head-property head :max-doc-len)))
+                                                          heads-in-row "| ")) "\n")
+             into matrix-image
+             finally return matrix-image)))
 ;; previous functions dealt with automatic docstring table generation from :column head property
 
 (defun hydra-idle-message (secs hint name)


### PR DESCRIPTION
This should fix the problem seen during merge of #220 

Incidentally, activating check-doc reveals some documentation issues in the previous PR I submitted as well as in existing code (80 col limit, first line must be sentence etc...). I think I'll fix that in a separate PR.