### PR TITLE
Declare the third argument of `defhydra’ as a (potential) docstring.

### DIFF
--- a/hydra.el
+++ b/hydra.el
@@ -1161,7 +1161,7 @@ It is possible to omit both BODY-MAP and BODY-KEY if you don't
 want to bind anything.  In that case, typically you will bind the
 generated NAME/body command.  This command is also the return
 result of `defhydra'."
-  (declare (indent defun))
+  (declare (indent defun) (doc-string 3))
   (setq heads (copy-tree heads))
   (cond ((stringp docstring))
         ((and (consp docstring)


### PR DESCRIPTION
This enables proper fontification of them within emacs-lisp-mode.