### PR TITLE
Make first line of hydra docstrings more informative.

### DIFF
--- a/hydra.el
+++ b/hydra.el
@@ -738,15 +738,14 @@ BODY-KEY is the body key binding.
 BODY-NAME is the symbol that identifies the Hydra.
 HEADS is a list of heads."
   (format
-   "Create a hydra with %s body and the heads:\n\n%s\n\n%s"
-   (if body-key
-       (format "a \"%s\"" body-key)
-     "no")
+   "The heads for the associated hydra are:\n\n%s\n\n%s%s."
    (mapconcat
     (lambda (x)
       (format "\"%s\":    `%S'" (car x) (cadr x)))
     heads ",\n")
-   (format "The body can be accessed via `%S'." body-name)))
+   (format "The body can be accessed via `%S'" body-name)
+   (when body-key
+     (format ", which is bound to \"%s\"" body-key))))
 
 (defun hydra--call-interactively-remap-maybe (cmd)
   "`call-interactively' the given CMD or its remapped equivalent.
@@ -783,8 +782,10 @@ BODY-AFTER-EXIT is added to the end of the wrapper."
                (hydra--make-callable
                 (cadr head))))
         (doc (if (car head)
-                 (format "%s\n\nCall the head: `%S'." doc (cadr head))
-               doc))
+                 (format "Call the head `%S' in the \"%s\" hydra.\n\n%s"
+                         (cadr head) name doc)
+               (format "Call the body in the \"%s\" hydra.\n\n%s"
+                       name doc)))
         (hint (intern (format "%S/hint" name)))
         (body-foreign-keys (hydra--body-foreign-keys body))
         (body-timeout (plist-get body :timeout))


### PR DESCRIPTION
Before this commit every head has the same first line for its docstring. The
distinguishing line is last. This change makes the distinguishing line appear
first in the docstring along with some minor wording changes.

For an application, see https://github.com/justbur/emacs-which-key/issues/185#issuecomment-361944776

* hydra.el (hydra--doc): Reword docstring.
(hydra--make-defun): Say which head is called in the first line.