### PR TITLE
hydra.el (hydra--make-defun): require hydra

### DIFF
--- a/hydra.el
+++ b/hydra.el
@@ -794,6 +794,7 @@ BODY-AFTER-EXIT is added to the end of the wrapper."
     `(defun ,cmd-name ()
        ,doc
        (interactive)
+       (require 'hydra)
        (hydra-default-pre)
        ,@(when body-pre (list body-pre))
        ,@(if (hydra--head-property head :exit)


### PR DESCRIPTION
When a user compiles hydras in a personal config file, it may be the case that
hydra is available at compilation time but has not been loaded when the file is
reloaded.