### PR TITLE
Disable fill-column-indicator display.

### DIFF
--- a/lv.el
+++ b/lv.el
@@ -55,6 +55,7 @@ Only the background color is significant."
   "Holds the current LV window.")
 
 (defvar display-line-numbers)
+(defvar display-fill-column-indicator)
 
 (defun lv-window ()
   "Ensure that LV window is live and return it."
@@ -76,6 +77,7 @@ Only the background color is significant."
           (setq header-line-format nil)
           (setq cursor-type nil)
           (setq display-line-numbers nil)
+          (setq display-fill-column-indicator nil)
           (set-window-dedicated-p lv-wnd t)
           (set-window-parameter lv-wnd 'no-other-window t))
         (select-window ori)))))


### PR DESCRIPTION
This disables fill-column-indicator (Emacs 27 feature) in hydra popups.