### PR TITLE
Fixed message hint display from being escaped by percent

### DIFF
--- a/hydra.el
+++ b/hydra.el
@@ -241,7 +241,7 @@ the body or the head."
 
 (defvar hydra-hint-display-alist
   (list (list 'lv #'lv-message #'lv-delete-window)
-        (list 'message #'message (lambda () (message "")))
+        (list 'message (lambda (str) (message "%s" str)) (lambda () (message "")))
         (list 'posframe #'hydra-posframe-show #'hydra-posframe-hide))
   "Store the functions for `hydra-hint-display-type'.")
 


### PR DESCRIPTION
If you run a hydra with `(setq hydra-hint-display-type 'message)` and then make it display a percent sign, the hydra crashes. This fixes that by disabling any `format` (which is what message runs it through before sending it to the minibuffer I think) string escaping. Or I guess it's not really escaping, just special syntax