### PR TITLE
Explicitly require cl-lib.

### DIFF
--- a/lv.el
+++ b/lv.el
@@ -33,6 +33,8 @@
 
 ;;; Code:
 
+(require 'cl-lib)
+
 (defgroup lv nil
   "The other echo area."
   :group 'minibuffer


### PR DESCRIPTION
This avoids a byte compilation warning:

```
$ emacs -Q -batch -f batch-byte-compile lv.el

In end of data:
lv.el:147:1:Warning: the function ‘cl-count’ is not known to be defined.
```