### PR TITLE
Don't open lv-buffers read-only

### DIFF
--- a/lv.el
+++ b/lv.el
@@ -84,6 +84,7 @@ Only the background color is significant."
             (switch-to-buffer buf 'norecord)
           (switch-to-buffer " *LV*" 'norecord)
           (fundamental-mode)
+          (read-only-mode 0)
           (set-window-hscroll lv-wnd 0)
           (setq window-size-fixed t)
           (setq mode-line-format nil)


### PR DESCRIPTION
A fix for a particular scenario: if you have Emacs configured to treat certain directories as read-only, and you try to use a hydra from a file in one of those directories, the lv buffer is opened read-only, which causes errors. (Difficult-to-understand errors, since they are not affected by `toggle-debug-on-error`.) 