### PR TITLE
Add GNU ELPA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Hydra
 
 [![Build Status](https://travis-ci.org/abo-abo/hydra.svg?branch=master)](https://travis-ci.org/abo-abo/hydra)
+[![GNU ELPA](https://elpa.gnu.org/packages/hydra.svg)](https://elpa.gnu.org/packages/hydra.html)
 [![MELPA](https://melpa.org/packages/hydra-badge.svg)](https://melpa.org/#/hydra)
 [![MELPA Stable](https://stable.melpa.org/packages/hydra-badge.svg)](https://stable.melpa.org/#/hydra)
 


### PR DESCRIPTION
GNU ELPA has badges now. This commit adds one to README.md.

You can see the badge here:
https://elpa.gnu.org/packages/hydra.svg

Thanks!