### PR TITLE
Fix emacs native compilation warning

### DIFF
--- a/hydra.el
+++ b/hydra.el
@@ -101,7 +101,8 @@
 This will be done even if the head wasn't designated for exiting.")
 
 (defvar hydra-amaranth-warn-message "An amaranth Hydra can only exit through a blue head"
-  "Amaranth Warning message.  Shown when the user tries to press an unbound/non-exit key while in an amaranth head.")
+  "Amaranth Warning message.  Shown when the user tries to press an
+unbound/non-exit key while in an amaranth head.")
 
 (defun hydra-set-transient-map (keymap on-exit &optional foreign-keys)
   "Set KEYMAP to the highest priority.


### PR DESCRIPTION
```
 ■  Warning (comp): hydra.el:103:2: Warning: defvar
`hydra-amaranth-warn-message' docstring wider than 80 characters
```

To reproduce, have emacs built with native compilation and notice the compilation logs. You can then open the offending file and run `M-x emacs-lisp-native-compile-and-load` before and after the changes to see the warning is removed.