### PR TITLE
Do as find-function-search-for-symbol does

### DIFF
--- a/hydra.el
+++ b/hydra.el
@@ -341,7 +341,7 @@ Exitable only through a blue head.")
         ;; The original function returns (cons (current-buffer) (point))
         ;; if it found the point.
         (unless (cdr ad-return-value)
-          (with-current-buffer (find-file-noselect library)
+          (with-current-buffer (find-file-noselect (find-library-name library))
             (let ((sn (symbol-name symbol)))
               (when (and (null type)
                          (string-match "\\`\\(hydra-[a-z-A-Z0-9]+\\)/\\(.*\\)\\'" sn)


### PR DESCRIPTION
The advised function calls find-library-name on library. Not following suit in the advice causes non-existent files to be opened.