### PR TITLE
Add `:inhibit-quit` property to improve performance

### DIFF
--- a/hydra.el
+++ b/hydra.el
@@ -916,9 +916,10 @@ BODY-AFTER-EXIT is added to the end of the wrapper."
          (body-on-exit-nil
           (delq
            nil
-           `((let ((hydra--ignore ,(not (eq (cadr head) 'body))))
-               (hydra-keyboard-quit)
-               (setq hydra-curr-body-fn ',curr-body-fn-sym))
+           `(,@(unless (hydra--head-property head :inhibit-quit)
+                 `((let ((hydra--ignore ,(not (eq (cadr head) 'body))))
+                     (hydra-keyboard-quit))))
+             (setq hydra-curr-body-fn ',curr-body-fn-sym)
              ,(when cmd
                 `(condition-case err
                      ,(hydra--call-interactively cmd (cadr head))


### PR DESCRIPTION
With this commit one can add the property `:inhibit-quit t` to a head to prevent the hydra from exiting temporarily before calling that head. (It is intended to be used and only effective on non-exiting heads.)

This greatly improves performance when calling heads repeatedly in quick succession, such as with scrolling or window resizing commands. In such cases the call to `hydra-keyboard-quit` (and the induced re-creation of the lv buffer and window) can easily become the bottleneck and is often unnecessary. (It is only necessary in special cases, for example, when a head reads from the minibuffer, or when it saves and switches window configurations.)

I would like to apply this option to the scrolling and window resizing hydra heads in Spacemacs, which currently suffer from relatively severe performance problems.