### PR TITLE
Port defadvice to define-advice

### DIFF
--- a/hydra.el
+++ b/hydra.el
@@ -331,24 +331,20 @@ Exitable only through a blue head.")
      2)))
 
 ;;* Find Function
-(eval-after-load 'find-func
-  '(defadvice find-function-search-for-symbol
-    (around hydra-around-find-function-search-for-symbol-advice
-     (symbol type library) activate)
-    "Navigate to hydras with `find-function-search-for-symbol'."
-    (prog1 ad-do-it
-      (when (symbolp symbol)
-        ;; The original function returns (cons (current-buffer) (point))
-        ;; if it found the point.
-        (unless (cdr ad-return-value)
-          (with-current-buffer (find-file-noselect library)
-            (let ((sn (symbol-name symbol)))
-              (when (and (null type)
-                         (string-match "\\`\\(hydra-[a-z-A-Z0-9]+\\)/\\(.*\\)\\'" sn)
-                         (re-search-forward (concat "(defhydra " (match-string 1 sn))
-                                            nil t))
-                (goto-char (match-beginning 0)))
-              (cons (current-buffer) (point)))))))))
+(define-advice find-function-search-for-symbol
+    (:around (fn symbol type library) hydra-around-find-function-search-for-symbol-advice)
+  (when (symbolp symbol)
+    ;; The original function returns (cons (current-buffer) (point))
+    ;; if it found the point.
+    (unless (cdr (funcall fn symbol type library))
+      (with-current-buffer (find-file-noselect library)
+	(let ((sn (symbol-name symbol)))
+	  (when (and (null type)
+		     (string-match "\\`\\(hydra-[a-z-A-Z0-9]+\\)/\\(.*\\)\\'" sn)
+		     (re-search-forward (concat "(defhydra " (match-string 1 sn))
+					nil t))
+	    (goto-char (match-beginning 0)))
+	  (cons (current-buffer) (point)))))))
 
 ;;* Universal Argument
 (defvar hydra-base-map


### PR DESCRIPTION
As of Emacs 30.1, `defadvice` has been marked obselete, and can lead to byte-compilation errors. Luckily, this is easy to fix; all we need to do is to replace invocations of `defadvice` with `define-advice`.

This also comes with some other minor benefits: we can remove the surrounding `eval-after-load 'find-func` from our advice, as `define-advice` can be used to advise functions that are not yet been defined.